### PR TITLE
Fix null exception when null returned from js function

### DIFF
--- a/substrata-kotlin/src/main/java/com/segment/analytics/substrata/kotlin/Conversions.kt
+++ b/substrata-kotlin/src/main/java/com/segment/analytics/substrata/kotlin/Conversions.kt
@@ -25,28 +25,29 @@ internal inline fun <reified T> JSConvertible.isTypeOf() = when(T::class) {
     JSArray::class -> context.isArray(ref)
     JSObject::class -> context.isObject(ref)
     JSFunction::class -> context.isFunction(ref)
+    JSException::class -> true
     else -> false
 }
 
 internal inline fun <reified T> JSConvertible.cast() =
     if (isTypeOf<T>()) wrap<T>()
-    else null
+    else throw Exception("Failed to cast JSConvertible. Unknown type is passed")
 
-fun JSConvertible.asString(): String? = cast()
+fun JSConvertible.asString(): String = cast()
 
-fun JSConvertible.asBoolean(): Boolean? = cast()
+fun JSConvertible.asBoolean(): Boolean = cast()
 
-fun JSConvertible.asInt(): Int?  = cast()
+fun JSConvertible.asInt(): Int  = cast()
 
-fun JSConvertible.asDouble(): Double?  = cast()
+fun JSConvertible.asDouble(): Double  = cast()
 
-fun JSConvertible.asJSArray(): JSArray? =  cast()
+fun JSConvertible.asJSArray(): JSArray=  cast()
 
-fun JSConvertible.asJSObject(): JSObject? = cast()
+fun JSConvertible.asJSObject(): JSObject = cast()
 
-fun JSConvertible.asJSFunction(): JSFunction? = cast()
+fun JSConvertible.asJSFunction(): JSFunction = cast()
 
-fun JSConvertible.asJSException(): JSException? = wrap()
+fun JSConvertible.asJSException(): JSException = wrap()
 
 fun String.toJSValue(context: JSContext) = context.newJSValue(this)
 

--- a/substrata-kotlin/src/main/java/com/segment/analytics/substrata/kotlin/JSContext.kt
+++ b/substrata-kotlin/src/main/java/com/segment/analytics/substrata/kotlin/JSContext.kt
@@ -34,7 +34,8 @@ class JSContext(
 
     fun evaluate(script: String): Any? {
         val ret = QuickJS.evaluate(contextRef, script, QuickJS.EVALUATOR, QuickJS.EVAL_TYPE_GLOBAL)
-        return getAny(ret)
+        val result = getAny(ret)
+        return if (result == JSNull) null else result
     }
 
 //    fun executeFunction(function: String, params: JSArray?): Any {

--- a/substrata-kotlin/src/main/java/com/segment/analytics/substrata/kotlin/JSContext.kt
+++ b/substrata-kotlin/src/main/java/com/segment/analytics/substrata/kotlin/JSContext.kt
@@ -84,7 +84,7 @@ class JSContext(
 
     fun getAny(ref: Long) = getAny(JSValue(ref, this))
 
-    fun getAny(value: JSValue): Any? {
+    fun getAny(value: JSValue): Any {
         val type = QuickJS.getType(value.ref)
         return when (type) {
             QuickJS.TYPE_STRING -> value.asString()
@@ -103,7 +103,7 @@ class JSContext(
                 }
             }
             QuickJS.TYPE_EXCEPTION -> value.asJSException()
-            QuickJS.TYPE_NULL -> null
+            QuickJS.TYPE_NULL -> JSNull
             QuickJS.TYPE_UNDEFINED -> JSUndefined
 //            QuickJS.TYPE_EXCEPTION -> getExecption()
             else -> throw Exception("Property type is undefined")


### PR DESCRIPTION
previously if a null is returned from a js function, the SDK tries to cast it to a non-null object, which generates a lot of exception messages in the log (though it does not crash the app). this pr fix the issue 