### PR TITLE
Support undefined parameter in function callback

### DIFF
--- a/gradle/mvn-publish.gradle
+++ b/gradle/mvn-publish.gradle
@@ -12,6 +12,10 @@ publishing {
             version getVersionName()
 
             artifact("$buildDir/outputs/aar/${project.getName()}-release.aar")
+            if (gradle.startParameter.taskNames.any { it.contains('publishToMavenLocal') }) {
+                artifact sourcesJar
+                artifact javadocJar
+            }
 
             // Self-explanatory metadata for the most part
             pom {

--- a/substrata-kotlin/build.gradle
+++ b/substrata-kotlin/build.gradle
@@ -51,6 +51,31 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     implementation "org.jetbrains.kotlin:kotlin-reflect:1.6.21"
 }
+task sourcesJar(type: Jar) {
+    archiveClassifier.set('sources')
+    from android.sourceSets.main.java.srcDirs
+}
+
+task javadoc(type: Javadoc) {
+    configurations.implementation.setCanBeResolved(true)
+
+    failOnError false
+    source = android.sourceSets.main.java.sourceFiles
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    classpath += configurations.implementation
+}
+
+// build a jar with javadoc
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    archiveClassifier.set('javadoc')
+    from javadoc.destinationDir
+}
+
+// Attach Javadocs and Sources jar
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}
 
 apply from: rootProject.file('gradle/mvn-publish.gradle')
 tasks.named("signReleasePublication") {

--- a/substrata-kotlin/src/androidTest/java/com/segment/analytics/substrata/kotlin/EngineTests.kt
+++ b/substrata-kotlin/src/androidTest/java/com/segment/analytics/substrata/kotlin/EngineTests.kt
@@ -600,6 +600,29 @@ class EngineTests {
     }
 
     @Test
+    fun testIncompatibleParameters() {
+        class MyJSClass {
+            fun test(a: String?, b: String, c: JSValue, d: Int): Int {
+                return d
+            }
+        }
+        scope.sync {
+            export( "MyJSClass", MyJSClass::class)
+            var res: Int = evaluate("""
+                let o = MyJSClass()
+                o.test(null, undefined, {}, 1234)
+            """) as Int
+            assertEquals(1234, res)
+
+            res = evaluate("""
+                o.test("a", "b", {}, 5678)
+            """) as Int
+            assertEquals(5678, res)
+        }
+        assertNotNull(exception)
+    }
+
+    @Test
     fun testAwait() {
         val ret = scope.await {
             export("add") { params ->

--- a/substrata-kotlin/src/main/java/com/segment/analytics/substrata/kotlin/Extensions.kt
+++ b/substrata-kotlin/src/main/java/com/segment/analytics/substrata/kotlin/Extensions.kt
@@ -1,4 +1,89 @@
 package com.segment.analytics.substrata.kotlin
 
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 
+fun KType.defaultValue(): Any? {
+    val classifier = this.classifier as? KClass<*>
+
+    // For nullable types, decide whether to return null or a default value
+    val shouldReturnNull = this.isMarkedNullable && when (classifier) {
+        String::class -> false  // Return "" even for String?
+        // Add other types where you want defaults instead of null
+        Int::class, Long::class, Double::class, Float::class, Boolean::class -> false
+        else -> true  // Return null for other nullable types
+    }
+
+    if (shouldReturnNull) return null
+
+    return when (classifier) {
+        // Primitives
+        String::class -> ""
+        Int::class -> 0
+        Long::class -> 0L
+        Double::class -> 0.0
+        Float::class -> 0.0f
+        Boolean::class -> false
+        Byte::class -> 0.toByte()
+        Short::class -> 0.toShort()
+        Char::class -> '\u0000'
+
+        // Collections
+        List::class -> emptyList<Any>()
+        Set::class -> emptySet<Any>()
+        Map::class -> emptyMap<Any, Any>()
+        Array::class -> emptyArray<Any>()
+
+        // Try to create instance with default constructor
+        else -> try {
+            classifier?.constructors?.firstOrNull {
+                it.parameters.all { param -> param.isOptional }
+            }?.callBy(emptyMap())
+        } catch (e: Exception) {
+            null
+        }
+    }
+}
+
+fun typesCompatible(parameterType: KType, actualValue: Any?): Boolean {
+    // Handle null values
+    if (actualValue == null) {
+        return parameterType.isMarkedNullable
+    }
+
+    val paramClassifier = parameterType.classifier as? KClass<*> ?: return false
+    val actualClass = actualValue::class
+
+    return when {
+        // Direct match
+        paramClassifier == actualClass -> true
+
+        // Check inheritance/interface implementation
+        paramClassifier.isInstance(actualValue) -> true
+
+        // Handle primitive boxing
+        isPrimitiveCompatible(paramClassifier, actualClass) -> true
+
+        // Handle generics (basic check)
+        paramClassifier.java.isAssignableFrom(actualClass.java) -> true
+
+        else -> false
+    }
+}
+
+private fun isPrimitiveCompatible(expected: KClass<*>, actual: KClass<*>): Boolean {
+    val primitiveMap = mapOf(
+        Int::class to setOf(java.lang.Integer::class, Int::class),
+        Long::class to setOf(java.lang.Long::class, Long::class),
+        Double::class to setOf(java.lang.Double::class, Double::class),
+        Float::class to setOf(java.lang.Float::class, Float::class),
+        Boolean::class to setOf(java.lang.Boolean::class, Boolean::class),
+        Byte::class to setOf(java.lang.Byte::class, Byte::class),
+        Short::class to setOf(java.lang.Short::class, Short::class),
+        Char::class to setOf(java.lang.Character::class, Char::class)
+    )
+
+    return primitiveMap[expected]?.contains(actual) == true ||
+            primitiveMap[actual]?.contains(expected) == true
+}


### PR DESCRIPTION
previously the SDK throws an exception if `undefined` is passed to an exported function. this pr fixed this issue by swapping out the incompatible value with default value of the corresponding type